### PR TITLE
Removed unneccesary "this" qualifier

### DIFF
--- a/lib/model_generator.dart
+++ b/lib/model_generator.dart
@@ -41,6 +41,7 @@ class ModelGenerator {
     if (hint.path == "") {
       return null;
     }
+    return null;
   }
 
   List<Warning> _generateClassDefinition(String className,

--- a/lib/syntax.dart
+++ b/lib/syntax.dart
@@ -126,7 +126,7 @@ class TypeDefinition {
   String toJsonExpression(String key, bool privateField) {
     final fieldKey =
         fixFieldName(key, typeDef: this, privateField: privateField);
-    final thisKey = 'this.$fieldKey';
+    final thisKey = fieldKey;
     if (isPrimitive) {
       return "data['$key'] = $thisKey;";
     } else if (name == 'List') {


### PR DESCRIPTION
Reference: Issue #82 

This pull request:
- Removes the unnecessary "this" qualifier from the code. (the main difference): The "this" qualifier is no longer needed in dart code (as described in #82).
- Makes a minor fix noticed from the dart analyzer (not really much of a difference)

